### PR TITLE
Changed check condition when a user types !use <Something> | Rogue

### DIFF
--- a/objects/User.js
+++ b/objects/User.js
@@ -226,7 +226,7 @@ module.exports = {
                 };
                 let updateSave = { $set: {_currentDeck: cleanedArg}};
                 bootstrap.User.updateOne(userQuery, updateSave, function(err, res){
-                    if (res){
+                    if (res.n > 0){
                         resolve("Success")
                      }
                      else{


### PR DESCRIPTION
A mongodb .UpdateOne function (being used here), will spit out information on whether or not it has modified any files. If it spits out a 0 (no files modified), then we know the user isn't registered. Changed check from simply finding a result to finding a result that was changed.

if (res) always passes, if (res.n>0) only passes if n (the number of modified files) has changed a file

closes #303 