### PR TITLE
Rework of Admin Functionality

### DIFF
--- a/Helpers/FunctionHelper.js
+++ b/Helpers/FunctionHelper.js
@@ -95,7 +95,7 @@ exampleDictionary =
     multiple inputs, as is highlighted below\n\
     Example usage: \n\
     !admin add @My Favorite People's Role @Another Discord Role @A third Role\n\
-    !add remove @Another Discord Role @A third Role",
+    !admin remove @Another Discord Role @A third Role",
 
     decks: "Use this function to list all decks on this server. This command will organize by color and then alphabetize all decks.\
     You can also search by 1, 2, 3 or 4-color pairings. Lastly, you can search the list of decks by commander. Use this function before you set your deck with !use <Deck Name>\n\n\

--- a/Helpers/FunctionHelper.js
+++ b/Helpers/FunctionHelper.js
@@ -44,7 +44,8 @@ adminDictionary =
     setendseason: "Sets an end date for the current season",
     setseasonname: "Sets a name for a season",
     setconfig: "Sets up configurations",
-    getconfig: "Displays configuration information"
+    getconfig: "Displays configuration information",
+    admin: "Sets Oracle Bot Admin Privileges"
 };
 
 exampleDictionary =
@@ -85,11 +86,16 @@ exampleDictionary =
     without the need for this command. This command will let you fine tune this experience in a variety of categories. These categories are:\n\n\
     'Player Threshold' - The minimum number of games before a player shows up in !top\n\
     'Deck Threshold' - The minimum number of games before a deck shows up in !deckstats\n\
-    'Admin' - The Discord roles which are allowed to use admin commands.\n\n\
-    Example usage: !setconfig <Config Type> | <New Value>. !setconfig Admin | Admin Role 1, Admin Role 2, Admin Role 3",
+    Example usage: !setconfig <Config Type> | <New Value>. !setconfig Player Threshold | 10",
     getconfig: "Use this function to get the current configurations for your server. This is an Admin-Only command and should be used in conjunction with !setconfig. This function\
     should be used to check your current configurations for your server. To see more information about what configurations there are and their users, type !help setconfig\n\n\
     Example usage: !getconfig",
+    admin: "Use this function to tell Oracle who has admin privileges. This is an Admin-Only command that should be used to allow users with certain @Discord Roles to access Admin-Only\
+    functions. This command has two modes: 'add' & 'remove'. 'Add' will add to your server's list of admin roles while 'Remove' will remove from your server's list of admin roles. Both accept\
+    multiple inputs, as is highlighted below\n\
+    Example usage: \n\
+    !admin add @My Favorite People's Role @Another Discord Role @A third Role\n\
+    !add remove @Another Discord Role @A third Role",
 
     decks: "Use this function to list all decks on this server. This command will organize by color and then alphabetize all decks.\
     You can also search by 1, 2, 3 or 4-color pairings. Lastly, you can search the list of decks by commander. Use this function before you set your deck with !use <Deck Name>\n\n\

--- a/Helpers/LeagueHelper.js
+++ b/Helpers/LeagueHelper.js
@@ -22,7 +22,7 @@ module.exports = {
                 resolve(configSaveRes)
             }
             else{
-                resolve("Error")
+                resolve("Error connecting to DB")
             }
         })
         })

--- a/Helpers/LeagueHelper.js
+++ b/Helpers/LeagueHelper.js
@@ -15,4 +15,16 @@ module.exports = {
         //     }
         // }
     },
+    createNewConfigs(receivedMessage, newSave){
+        return new Promise((resolve, reject)=>{
+        bootstrap.Config(newSave).save({_server: receivedMessage.guild.id}, function(err,configSaveRes){
+            if (configSaveRes){
+                resolve(configSaveRes)
+            }
+            else{
+                resolve("Error")
+            }
+        })
+        })
+    }
 };

--- a/Schema/Config.js
+++ b/Schema/Config.js
@@ -6,7 +6,7 @@ var config = new mongoose.Schema({
     _player_threshold: String,
     _deck_threshold: String,
     _timeout: String,
-    _admin: String
+    _admin: Array
 });
 
 module.exports = mongoose.model('Config', config);

--- a/main.js
+++ b/main.js
@@ -210,6 +210,14 @@ async function processCommand(receivedMessage){
                 bootstrap.OracleObj.nonAdminAccess(receivedMessage, primaryCommand);
             }
             break;
+        case "admin":
+            if (adminGet){
+                bootstrap.OracleObj.adminSet(receivedMessage, rawArguments);
+            }
+            else{
+                bootstrap.OracleObj.nonAdminAccess(receivedMessage, primaryCommand);
+            }
+            break;
         case "setconfig":
             if (adminGet){
                 bootstrap.OracleObj.configSet(receivedMessage, rawArguments);

--- a/objects/League.js
+++ b/objects/League.js
@@ -55,20 +55,17 @@ module.exports = {
     /**
      * Sets a configuration
      */
-    configSet(receivedMessage, args) {
+     configSet(receivedMessage, args) {
         let argsWithCommas = args.toString();
         let argsWithSpaces = argsWithCommas.replace(/,/g, ' ');
         let splitArgs = argsWithSpaces.split(" | ");
-        splitArgs[0] = splitArgs[0].toLowerCase();
+        splitArgs[0] = splitArgs[0].toLowerCase().trim();
         
         return new Promise((resolve, reject)=>{
             let conditionalQuery;
             let playerThreshold = 10;
             let deckThreshold = 10;
-            let admin = "";
-            let adminList;
-            if ((splitArgs[0]!== "player threshold") && (splitArgs[0]!== "deck threshold")
-            &&(splitArgs[0]!== "admin")){
+            if ((splitArgs[0] !== "player threshold") && (splitArgs[0] !== "deck threshold")){
                 resolve("Invalid Input")
             }
             else if (splitArgs.length === 1){
@@ -99,14 +96,6 @@ module.exports = {
                             deckThreshold = splitArgs[1]
                         }
                     }
-                }else if ((splitArgs[0] === "admin")){
-                    adminList = splitArgs[1];
-                    adminList = adminList.replace(/  /g, ', ')
-                    conditionalQuery = {
-                        _server: receivedMessage.guild.id,
-                        _admin: adminList
-                    };
-                    admin = adminList
                 }
                 else{
                     resolve("Invalid Input")
@@ -115,39 +104,155 @@ module.exports = {
                     _server: receivedMessage.guild.id,
                     _player_threshold: playerThreshold,
                     _deck_threshold: deckThreshold,
-                    _admin: admin, 
                 };
-                bootstrap.Config.updateOne({_server: receivedMessage.guild.id}, conditionalQuery, function(err,res){
+                bootstrap.Config.updateOne({_server: receivedMessage.guild.id}, conditionalQuery, async function(err,res){
                     if (res.n > 0){
                         let savedValue = splitArgs[1];
-                        if (splitArgs[0] === "admin"){
-                            savedValue = adminList
-                        }
                         let resArr = [];
                         resArr.push("Updated", splitArgs[0], savedValue);
                         resolve(resArr)
                     }
                     else{
-                        bootstrap.Config(newSave).save({_server: receivedMessage.guild.id}, function(err,configSaveRes){
-                            if (res){
-                                let savedValue = splitArgs[1];
-                                if (splitArgs[0] === "admin"){
-                                    savedValue = adminList
-                                }
-                                let resArr = [];
-                                resArr.push("New Save", splitArgs[0], savedValue);
-                                resolve(resArr)
-                            }
-                            else{
-                                resolve("Error")
-                            }
-                        })
+                        let newSaveRes = await bootstrap.LeagueHelper.createNewConfigs(receivedMessage, newSave);
+                        if (newSaveRes !== "Error"){
+                            let savedValue = splitArgs[1];
+                            let resArr = [];
+                            resArr.push("New Save", splitArgs[0], savedValue);
+                            resolve(resArr)
+                        }else{
+                            resolve("Error")
+                        }
                     }
                 })
             }
         })
     },
+    async adminAppend(receivedMessage, discordRoles){
+        let newDiscordRoles = [];
+        let newSaveBool = false;
+        return new Promise((resolve, reject)=>{
+            bootstrap.Config.findOne({_server:receivedMessage.guild.id}).then(async foundRes=>{
+                if (foundRes){
+                    discordRoles.forEach((entry)=>{
+                        if(foundRes._admin.includes(entry)){
+                        }
+                        else{
+                            newDiscordRoles.push(entry)
+                        }
+                    })
+                }
+                else{
+                    let newSave = {
+                        _server: receivedMessage.guild.id,
+                        _player_threshold: 10,
+                        _deck_threshold: 10,
+                    };
+                    let newSaveRes = await bootstrap.LeagueHelper.createNewConfigs(receivedMessage, newSave);
+                    if (newSaveRes !== "Error"){
+                        if (discordRoles.length > 0){
+                            discordRoles.forEach((adminEntry)=>{
+                                let adminToAppend = {
+                                    $push:{
+                                        _admin: adminEntry
+                                    }
+                                };
+                                bootstrap.Config.updateOne({_server: receivedMessage.guild.id}, adminToAppend, function(err, res){
+                                    if (err){
+                                        console.log(err)
+                                    }
+                                })
+                            });
+                            newSaveBool = true;
+                        }
+                    }else{
+                        let retArr = [];
+                        retArr.push("DB Connect Error", newDiscordRoles);
+                        resolve(retArr)
+                    }
+                }
 
+            })
+            .then(function(e){
+                if (newDiscordRoles.length > 0){
+                    newDiscordRoles.forEach((adminEntry)=>{
+                        let adminToAppend = {
+                            $push:{
+                                _admin: adminEntry
+                            }
+                        };
+                        bootstrap.Config.updateOne({_server: receivedMessage.guild.id}, adminToAppend, function(err, res){
+                            if (err){
+                                let retArr = [];
+                                retArr.push("DB Connect Error", newDiscordRoles);
+                                resolve(retArr)
+                            }
+                            else{
+                                let retArr = [];
+                                retArr.push("Success", newDiscordRoles);
+                                resolve(retArr)
+                            }
+                        })
+                    })
+                }
+                else if (!newSaveBool){
+                    let retArr = [];
+                    retArr.push("No New Roles Error", newDiscordRoles);
+                    resolve(retArr)
+                }
+                else{
+                    let retArr = [];
+                    retArr.push("New Success", newDiscordRoles);
+                    resolve(retArr)
+                }
+            });
+        });
+    },
+    adminDelete(receivedMessage, discordRoles){
+        let newDiscordRoles = [];
+        return new Promise((resolve, reject)=>{
+            bootstrap.Config.findOne({_server: receivedMessage.guild.id}).then(async foundRes=>{
+                if (foundRes){
+                    discordRoles.forEach((entry)=>{
+                        if(foundRes._admin.includes(entry)){
+                            newDiscordRoles.push(entry)
+                        }
+                    })
+                }
+                else{
+                    let retArr = [];
+                    retArr.push("No Config Error", newDiscordRoles);
+                    resolve(retArr)
+                }
+            }).then(function(e){
+                if (newDiscordRoles.length > 0){
+                    newDiscordRoles.forEach((adminEntry)=>{
+                        let adminToAppend = {
+                            $pull:{
+                                _admin: adminEntry
+                            }
+                        };
+                        bootstrap.Config.updateOne({_server: receivedMessage.guild.id}, adminToAppend, function(err, res){
+                            if (err){
+                                let retArr = [];
+                                retArr.push("DB Connect Error", newDiscordRoles);
+                                resolve(retArr)
+                            }
+                            else{
+                                let retArr = [];
+                                retArr.push("Success", newDiscordRoles);
+                                resolve(retArr)
+                            }
+                        })
+                    })
+                }
+                else{
+                    let retArr = [];
+                    retArr.push("No Roles Error", newDiscordRoles);
+                    resolve(retArr)
+                }
+            });
+        })
+    },
     /**
      * gets a configuration
      */

--- a/objects/League.js
+++ b/objects/League.js
@@ -114,13 +114,13 @@ module.exports = {
                     }
                     else{
                         let newSaveRes = await bootstrap.LeagueHelper.createNewConfigs(receivedMessage, newSave);
-                        if (newSaveRes !== "Error"){
+                        if (newSaveRes !== "Error connecting to DB"){
                             let savedValue = splitArgs[1];
                             let resArr = [];
                             resArr.push("New Save", splitArgs[0], savedValue);
                             resolve(resArr)
                         }else{
-                            resolve("Error")
+                            resolve("Error connecting to DB")
                         }
                     }
                 })

--- a/objects/Oracle.js
+++ b/objects/Oracle.js
@@ -316,11 +316,11 @@ module.exports = {
                 .setFooter("A default set of configuration values are set for every server. Update these configs to fine tune your experience");
             generalChannel.send(errorEmbed)
         }
-        else if (returnArr === "Error"){
+        else if (returnArr === "Error connecting to DB"){
             const errorEmbed = new bootstrap.Discord.MessageEmbed()
                 .setColor(bootstrap.messageColorRed)
-                .setAuthor("Error")
-                .setDescription("An Error has occurred, please try again");
+                .setAuthor("Error connecting to database")
+                .setDescription("An Error connecting to the database has occurred, please try again");
             generalChannel.send(errorEmbed)
         }
         else if (returnArr[0] === "Updated"){

--- a/objects/Oracle.js
+++ b/objects/Oracle.js
@@ -204,6 +204,102 @@ module.exports = {
             generalChannel.send(noConfigEmbed)
         }
     },
+    async adminSet(receivedMessage, args){
+        let generalChannel = bootstrap.MessageHelper.getChannelID(receivedMessage);
+        if (args[0].toLowerCase().trim() === "add"){
+            let discordRolesWithDups = [];
+            for (i = 1; i < args.length; i++){
+                if (receivedMessage.guild.roles.cache.find(role => "<@&"+role.id+">" === args[i]) !== undefined){
+                    discordRolesWithDups.push(args[i])
+                }
+            }
+            let holderDiscordRoles = new Set(discordRolesWithDups);
+            let discordRoles = [...holderDiscordRoles];
+            let returnRes = await bootstrap.LeagueObj.adminAppend(receivedMessage, discordRoles);
+            if (returnRes[0] === "Success"){
+                const successEmbed = new bootstrap.Discord.MessageEmbed()
+                    .setColor(bootstrap.messageColorGreen)
+                    .setAuthor("Successfully set new Admins roles")
+                    .setDescription("Added new discord roles to this server's list of admins: \n\ " + returnRes[1]);
+                generalChannel.send(successEmbed)
+            }
+            else if (returnRes[0] === "New Success"){
+                const successEmbed = new bootstrap.Discord.MessageEmbed()
+                    .setColor(bootstrap.messageColorGreen)
+                    .setAuthor("Successfully set new Admins roles and created configs for this server")
+                    .setDescription("Added new discord roles to this server's list of admins: \n\ " + returnRes[1]);
+                generalChannel.send(successEmbed)
+            }
+            else if (returnRes[0] === "DB Connect Error"){
+                const errorEmbed = new bootstrap.Discord.MessageEmbed()
+                    .setColor(bootstrap.messageColorRed)
+                    .setAuthor("Error: Unable to Add Roles")
+                    .setDescription("Unable to connect to Data Base. Please try again");
+
+                generalChannel.send(errorEmbed)
+            }
+            else if (returnRes[0] === "No New Roles Error"){
+                const errorEmbed = new bootstrap.Discord.MessageEmbed()
+                    .setColor(bootstrap.messageColorRed)
+                    .setAuthor("Error: Unable to Add Roles")
+                    .setDescription("All the roles you're attempting to add are already present in your configurations")
+                    .setFooter("Try typing !getconfigs to see a list of admin roles \n\To remove roles, type !admin remove <@Discord Roles Here>");
+                generalChannel.send(errorEmbed)
+            }
+        }
+        else if (args[0].toLowerCase().trim() === "remove"){
+            let discordRolesWithDups = [];
+            for (i = 1; i < args.length; i++){
+                if (receivedMessage.guild.roles.cache.find(role => "<@&"+role.id+">" === args[i]) !== undefined){
+                    discordRolesWithDups.push(args[i])
+                }
+            }
+            let holderDiscordRoles = new Set(discordRolesWithDups);
+            let discordRoles = [...holderDiscordRoles];
+            let returnRes = await bootstrap.LeagueObj.adminDelete(receivedMessage, discordRoles)
+            if (returnRes[0] === "Success"){
+                const successEmbed = new bootstrap.Discord.MessageEmbed()
+                    .setColor(bootstrap.messageColorGreen)
+                    .setAuthor("Successfully removed Admins roles")
+                    .setDescription("Removed discord roles from this server's list of admins: \n\ " + returnRes[1]);
+                generalChannel.send(successEmbed)
+            }
+            else if (returnRes[0] === "No Roles Error"){
+                const successEmbed = new bootstrap.Discord.MessageEmbed()
+                    .setColor(bootstrap.messageColorRed)
+                    .setAuthor("Error: Unable to Remove Roles")
+                    .setDescription("All of the roles you're attempting to remove are not present in your configurations")
+                    .setFooter("Try typing !getconfigs to see a list of admin roles \n\To add roles, type !admin add <@Discord Roles Here>");
+                generalChannel.send(successEmbed)
+            }
+            else if (returnRes[0] === "DB Connect Error"){
+                const errorEmbed = new bootstrap.Discord.MessageEmbed()
+                    .setColor(bootstrap.messageColorRed)
+                    .setAuthor("Error: Unable to Add Roles")
+                    .setDescription("Unable to connect to Data Base. Please try again");
+
+                generalChannel.send(errorEmbed)
+            }
+            else if (returnRes[0] === "No Config Error"){
+                const errorEmbed = new bootstrap.Discord.MessageEmbed()
+                    .setColor(bootstrap.messageColorRed)
+                    .setAuthor("Error: Unable to Remove Roles")
+                    .setDescription("Your server has no Admin Roles set.")
+                    .setFooter("All users that have Discord Roles with administrative privileges have Oracle Bot Admin Privileges\n\To add roles, type !admin add <@Discord Roles Here>");
+                generalChannel.send(errorEmbed)
+            }
+        }
+        else{
+            const errorEmbed = new bootstrap.Discord.MessageEmbed()
+                .setColor(bootstrap.messageColorRed)
+                .setAuthor("Incorrect Input")
+                .setDescription("Please retry entering your list of admins in either format below: \n\
+                !admin add <@discord role>\n\
+                !admin remove <@discord role>")
+                .setFooter("For more info, type !help admin");
+            generalChannel.send(errorEmbed)
+        }
+    },
     async configSet(receivedMessage, args){
         let generalChannel = bootstrap.MessageHelper.getChannelID(receivedMessage);
         let returnArr = await bootstrap.LeagueObj.configSet(receivedMessage, args);
@@ -216,7 +312,6 @@ module.exports = {
         The types of configurations are:\n\
         'Player Threshold (A **number**)', \n\
         'Deck Threshold (A **number**)', \n\
-        'Admin' (A list of **Discord Roles** seperated by commas)\n\n\
         **Confused on what these mean? Try !help setconfig**")
                 .setFooter("A default set of configuration values are set for every server. Update these configs to fine tune your experience");
             generalChannel.send(errorEmbed)


### PR DESCRIPTION
-Admin extrapolated into its own function
-Two pieces of functionality: "Add" and "Remove"
-Add --> adds to server's list of configs' Admin (Disord Roles)
-Remove --> removes ... same as above ^

-Notes:
-Bot will check if what you're typing is a discord role in that server before adding it
-Bot accepts multiple roles at once
-Bot will accept incorrect and correct inputs in the same input.
Example: Trying to remove 2 discord roles from the list of admins, one that is actually in the list and one that is not

-Updated tool tips and !help commands

closes #340 